### PR TITLE
🐛Fix: split Authorization Token, use expires env

### DIFF
--- a/src/config/jwt/jwt.config.ts
+++ b/src/config/jwt/jwt.config.ts
@@ -13,7 +13,7 @@ export function getJwtModuel(): DynamicModule {
        */
       signOptions: {
         issuer: 'pyc',
-        expiresIn: configService.get('JWT_EXPIRES_IN'),
+        expiresIn: `${configService.get('JWT_EXPIRES_IN')}`,
       },
     }),
   });

--- a/src/modules/auth/v1/controllers/auth.controller.ts
+++ b/src/modules/auth/v1/controllers/auth.controller.ts
@@ -11,7 +11,7 @@ export class AuthController {
 
   @Get('token/validate')
   validateToken(@Headers('Authorization') auth: string): ValidateResponse {
-    const [_, token] = auth.split(' ')[1];
+    const [_, token] = auth.split(' ');
     return this.authService.isValidated(token);
   }
 
@@ -22,13 +22,13 @@ export class AuthController {
 
   @Post('/logout')
   async logout(@Headers('Authorization') auth: string) {
-    const [_, token] = auth.split(' ')[1];
+    const [_, token] = auth.split(' ');
     return this.authService.refresh(token);
   }
 
   @Put('/refresh')
   async refresh(@Headers('Authorization') auth: string): Promise<TokenResponse> {
-    const [_, token] = auth.split(' ')[1];
+    const [_, token] = auth.split(' ');
     return this.authService.refresh(token);
   }
 


### PR DESCRIPTION
## Description

- Controller에서 Authorization Header를 얻을 때 split을 사용는 방법이 잘못 되었음

```ts
// 잘못된 방법
const [_, token] = auth.split(' ')[1];

// 수정
const [_, token] = auth.split(' ');
```

빠르게 작성하지 말고 꼼꼼히 하자