### PR TITLE
Bugfix 44 calendar fetch

### DIFF
--- a/src/modules/calendar/v1/controllers/calendar.controller.ts
+++ b/src/modules/calendar/v1/controllers/calendar.controller.ts
@@ -6,6 +6,7 @@ import { CreateCalendarRequest } from 'src/dto/calendar/requests/create-calendar
 import { UpdateCalendarRequest } from 'src/dto/calendar/requests/update-calendar.request';
 import { CalendarListResponse } from 'src/dto/calendar/responses/calendar-list.response';
 import { PycUser } from 'src/dto/common/dto/pyc-user.dto';
+import { getJsMonth, getMonthString } from 'src/utils/date';
 import { ICalendarService } from '../interfaces/calendar-service.interface';
 import { CalendarServiceKey } from '../services/calendar.service';
 
@@ -19,7 +20,8 @@ export class CalendarController {
     @Query() query: CalendarListQuery,
   ): Promise<CalendarListResponse> {
     const { year, month, offset, limit } = query;
-    return this.service.getCalendarsByMonth(pycUser, new Date(`${year}-${month}`), { offset, limit });
+    const monthString = getMonthString(getJsMonth(Number(month)));
+    return this.service.getCalendarsByMonth(pycUser, new Date(`${year}-${monthString}`), { offset, limit });
   }
 
   @Post()

--- a/src/modules/calendar/v1/services/calendar.service.ts
+++ b/src/modules/calendar/v1/services/calendar.service.ts
@@ -7,7 +7,7 @@ import { PycUser } from 'src/dto/common/dto/pyc-user.dto';
 import { Calendar } from 'src/entities/calendar-event/calendar.entity';
 import { Church } from 'src/entities/church/church.entity';
 import { User } from 'src/entities/user/user.entity';
-import { getMonthLastDay } from 'src/utils/date';
+import { getMonthFirstDay, getMonthLastDay, getMonthString, getPrevMonthLastDay } from 'src/utils/date';
 import { DataSource, Repository } from 'typeorm';
 import { ICalendarService } from '../interfaces/calendar-service.interface';
 
@@ -47,7 +47,7 @@ export class CalendarService implements ICalendarService {
     options?: { offset: number; limit: number } | undefined,
   ): Promise<CalendarListResponse> {
     const { churchId } = pycUser;
-    const first = monthDate;
+    const first = getPrevMonthLastDay(monthDate);
     const last = getMonthLastDay(monthDate);
 
     const [rows, count] = await this.repository

--- a/src/modules/calendar/v1/services/calendar.service.ts
+++ b/src/modules/calendar/v1/services/calendar.service.ts
@@ -7,7 +7,7 @@ import { PycUser } from 'src/dto/common/dto/pyc-user.dto';
 import { Calendar } from 'src/entities/calendar-event/calendar.entity';
 import { Church } from 'src/entities/church/church.entity';
 import { User } from 'src/entities/user/user.entity';
-import { getMonthFirstDay, getMonthLastDay } from 'src/utils/date';
+import { getMonthLastDay } from 'src/utils/date';
 import { DataSource, Repository } from 'typeorm';
 import { ICalendarService } from '../interfaces/calendar-service.interface';
 
@@ -47,9 +47,9 @@ export class CalendarService implements ICalendarService {
     options?: { offset: number; limit: number } | undefined,
   ): Promise<CalendarListResponse> {
     const { churchId } = pycUser;
-
-    const first = getMonthFirstDay(monthDate);
+    const first = monthDate;
     const last = getMonthLastDay(monthDate);
+
     const [rows, count] = await this.repository
       .createQueryBuilder('calendar')
       .leftJoinAndMapOne('calendar.cUser', User, 'c_user', 'calendar.created_by = c_user.id')

--- a/src/utils/date/__test__/date.spec.ts
+++ b/src/utils/date/__test__/date.spec.ts
@@ -2,6 +2,7 @@ import {
   getMonthFirstDay,
   getMonthLastDay,
   getMonthString,
+  getPrevMonthLastDay,
   getYearFirstDay,
   getYearLastDay,
   getYearString,
@@ -72,5 +73,28 @@ describe('Custom Date Function', () => {
 
     //then
     expect(result).toEqual(new Date('2022-12-31'));
+  });
+
+  it('get Prev Month Last Day', () => {
+    //given
+    const date = new Date('2022-12-01');
+    const copyDate = new Date(date);
+
+    //when
+    copyDate.setHours(-1);
+
+    //then
+    expect(`${copyDate.getFullYear()}-${getMonthString(copyDate.getMonth())}-${copyDate.getDate()}`).toBe('2022-11-30');
+  });
+
+  it('getPrevMonthLastDay', () => {
+    //given
+    const date = new Date('2022-12-01');
+
+    //when
+    const prevLastMonthLastDay = getPrevMonthLastDay(date);
+
+    //then
+    expect(prevLastMonthLastDay).toStrictEqual(new Date('2022-11-30'));
   });
 });

--- a/src/utils/date/__test__/date.spec.ts
+++ b/src/utils/date/__test__/date.spec.ts
@@ -24,7 +24,7 @@ describe('Custom Date Function', () => {
     const date = new Date('2022-11-03');
 
     //when
-    const result = getMonthString(date);
+    const result = getMonthString(date.getMonth());
 
     //then
     expect(result).toBe('11');

--- a/src/utils/date/date.ts
+++ b/src/utils/date/date.ts
@@ -43,6 +43,19 @@ export const getMonthLastDay = (date: Date): Date => {
   return new Date(`${year}-${month}-${new Date(+year, +month, 0).getDate()}`);
 };
 
+/**
+ * getPrevMonthLastDay
+ *
+ * @description 월의 첫번째 일 00시의 Date를 받아 이전 달 마지말 날을 구하는 method
+ * @param date {@link date} 월의 처음 날 00시 ex: 2022-12-01T00:00:00.000Z
+ * @returns 이전 달 마지막 날
+ */
+export const getPrevMonthLastDay = (date: Date): Date => {
+  const copyDate = new Date(date);
+  copyDate.setHours(-1);
+  return new Date(`${copyDate.getFullYear()}-${getMonthString(copyDate.getMonth())}-${copyDate.getDate()}`);
+};
+
 export const getYearFirstDay = (date: Date): Date => {
   return new Date(`${date.getFullYear().toString()}-01-01`);
 };

--- a/src/utils/date/date.ts
+++ b/src/utils/date/date.ts
@@ -1,28 +1,45 @@
+/**
+ * getJsMonth
+ *
+ * @description JS에서 Date.getMonth()를 하게 되면 해당 (월 - 1)을 해주게 된다.
+ * FE에서 받는 Month를 getMonth()와 동일하게 parsing
+ * @param month{@link month}
+ * @returns month - 1
+ */
+export const getJsMonth = (month: number): number => {
+  return month === 1 ? 0 : month - 1;
+};
+
+/**
+ * getMonthString
+ *
+ * @description JsMonth를 parsing하여 month를 String으로 반환하는 method
+ * @param month {@link month} JsMonth로 (월 - 1)이 들어오게 된다.
+ * @returns 1월 "01" , 2~9월 "0${month + 1}", 10월부터 11월 "${month +1}"
+ */
+export const getMonthString = (month: number): string => {
+  if (month === 0) {
+    return '01';
+  } else if (10 > month) {
+    return `0${month + 1}`;
+  } else {
+    return `${month + 1}`;
+  }
+};
+
 export const getYearString = (date: Date): string => {
   return date.getFullYear().toString();
 };
 
-export const getMonthString = (date: Date): string => {
-  const monthString = date.getMonth().toString();
-
-  if (monthString === '0') {
-    return '01';
-  } else if (monthString.length === 1) {
-    return `0${monthString}`;
-  } else {
-    return (+monthString + 1).toString();
-  }
-};
-
 export const getMonthFirstDay = (date: Date): Date => {
   const year = getYearString(date);
-  const month = getMonthString(date);
+  const month = getMonthString(date.getMonth());
   return new Date(`${year}-${month}-01`);
 };
 
 export const getMonthLastDay = (date: Date): Date => {
   const year = getYearString(date);
-  const month = getMonthString(date);
+  const month = getMonthString(date.getMonth());
   return new Date(`${year}-${month}-${new Date(+year, +month, 0).getDate()}`);
 };
 


### PR DESCRIPTION
## 작업내용

- FE에서 Month 데이터  `toJsMonth`로 파싱하여 사용
- 모든 월의 1일 isAllDay의 이벤트가 보이지 않는 것을 수정 -> 조회 조건을 이전 달 마지막 날부터
- 테스트코드