### PR TITLE
⚡️Improve: define genericTypeOrm repository, test

### DIFF
--- a/src/core/database/typeorm/generic-typeorm.repository.spec.ts
+++ b/src/core/database/typeorm/generic-typeorm.repository.spec.ts
@@ -1,0 +1,119 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { createNamespace } from 'cls-hooked';
+import { BaseTimeEntity } from 'src/entities/base-time.entity';
+import { PostgreSqlContainer, StartedPostgreSqlContainer } from 'testcontainers';
+import { DataSource, Entity, EntityTarget } from 'typeorm';
+import { GenericTypeOrmRepository } from './generic-typeorm.repository';
+import { TransactionManager } from './transaction.manager';
+import { PYC_ENTITY_MANAGER, PYC_NAMESPACE } from './transaction.middleware';
+
+@Entity()
+class Mock extends BaseTimeEntity {}
+
+class MockRepository extends GenericTypeOrmRepository<Mock> {
+  getName(): EntityTarget<Mock> {
+    return Mock.name;
+  }
+}
+
+describe('GenericTypeOrm Repository', () => {
+  jest.setTimeout(300_000);
+
+  let container: StartedPostgreSqlContainer;
+  let dataSource: DataSource;
+  let mockRepository: MockRepository;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:latest').withExposedPorts(5432).start();
+    dataSource = new DataSource({
+      type: 'postgres',
+      host: container.getHost(),
+      port: container.getPort(),
+      database: container.getDatabase(),
+      username: container.getUsername(),
+      password: container.getPassword(),
+      synchronize: true,
+      entities: [Mock],
+      logging: true,
+    });
+    await dataSource.initialize();
+
+    mockRepository = new MockRepository(new TransactionManager());
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+    await container.stop();
+  });
+
+  it('Should be defined', () => {
+    expect(container).toBeDefined();
+    expect(dataSource).toBeDefined();
+    expect(mockRepository).toBeDefined();
+  });
+
+  it('NameSpace가 존재하지 않는 경우', async () => {
+    //given
+    const e = new Mock();
+
+    //when
+    //then
+    await expect(mockRepository.save(e)).rejects.toThrowError(
+      new InternalServerErrorException(`${PYC_NAMESPACE} is not active`),
+    );
+  });
+
+  it('NameSpace가 있지만 active 상태가 아닌 경우', async () => {
+    //given
+    const e = new Mock();
+    createNamespace(PYC_NAMESPACE);
+
+    //when
+    //then
+    await expect(mockRepository.save(e)).rejects.toThrowError(
+      new InternalServerErrorException(`${PYC_NAMESPACE} is not active`),
+    );
+  });
+
+  it('정상적으로 저장 with Save & findOne', async () => {
+    //given
+    const e = new Mock();
+    const namespace = createNamespace(PYC_NAMESPACE);
+
+    //when
+    await namespace.runPromise(async () => {
+      //set EntityManager
+      await Promise.resolve().then(() => namespace.set(PYC_ENTITY_MANAGER, dataSource.createEntityManager()));
+
+      // save
+      await mockRepository.save(e);
+
+      //then
+      const result = await mockRepository.findById(1);
+      expect(result).not.toBeNull();
+    });
+  });
+
+  it('정상적으로 삭제 with Save & remove & findOne', async () => {
+    //given
+    const e = new Mock();
+    const namespace = createNamespace(PYC_NAMESPACE);
+
+    //when
+    await namespace.runPromise(async () => {
+      //set EntityManager
+      await Promise.resolve().then(() => namespace.set(PYC_ENTITY_MANAGER, dataSource.createEntityManager()));
+
+      // save
+      await mockRepository.save(e);
+      const result = await mockRepository.findById(1);
+
+      // remove
+      await mockRepository.remove(result!);
+
+      //then
+      const notExist = await mockRepository.findById(1);
+      expect(notExist).toBeNull();
+    });
+  });
+});

--- a/src/core/database/typeorm/generic-typeorm.repository.ts
+++ b/src/core/database/typeorm/generic-typeorm.repository.ts
@@ -1,0 +1,46 @@
+import { BaseTimeEntity } from 'src/entities/base-time.entity';
+import { FindOneOptions, Repository, EntityTarget, EntityManager } from 'typeorm';
+import { TransactionManager } from './transaction.manager';
+
+/**
+ * GenericTypeOrmRepository
+ *
+ * @description ORM을 이용하여 공통적으로 사용하는 Save, FindById, Remove를 구현한 Abstract Class
+ * 모든 Entity의 Repository는 해당 Repository를 구현하여 추가적인 CRUD method를 확장할 수 있다.
+ */
+export abstract class GenericTypeOrmRepository<T extends BaseTimeEntity> {
+  constructor(private readonly txManger: TransactionManager) {}
+
+  /**
+   * getName
+   *
+   * @description TypeORM에서 Repository를 EntityManager에서 가져올 때 {@link EntityTarget}을 통해 가져오게 된다.
+   * EntityTarget의 Union 타입 중 Entity Name으로 Repository를 가져올 수 있다. {@link GenericTypeOrmRepository}를
+   * 구현하는 Repository는 getName()만 구현하면 된다.
+   */
+  abstract getName(): EntityTarget<T>;
+
+  async save(t: T | T[]): Promise<void> {
+    await this.getRepository().save(Array.isArray(t) ? t : [t]);
+  }
+
+  async findById(id: number): Promise<T | null> {
+    const findOption: FindOneOptions = { where: { id } };
+    return this.getRepository().findOne(findOption);
+  }
+
+  async remove(t: T | T[]): Promise<void> {
+    await this.getRepository().remove(Array.isArray(t) ? t : [t]);
+  }
+
+  /**
+   * getRepository
+   *
+   * @description 구현을 하는 자식 class에서 getName()을 통해 얻어온 {@link EntityTarget}을 통해
+   * {@link EntityManager}에서 Repository를 얻어온다. 해당 method는 구현한 class에서는 호출이 가능하다.
+   * @returns repository {@link Repository}
+   */
+  protected getRepository(): Repository<T> {
+    return this.txManger.getEntityManager().getRepository(this.getName());
+  }
+}


### PR DESCRIPTION
## 작업내용

- 공통적인 CRUD에 대한 정의를 한 `GenericTypeOrmRepository`를 구현
  - Save( t: T | T[] )
  - findById( id:number )
  - remove( t: T | T[] )   

- 테스트 코드 작성